### PR TITLE
[minor] Remove prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "start": "tsdx watch",
     "build": "tsdx build",
     "test": "tsdx test",
-    "lint": "tsdx lint",
-    "prepare": "tsdx build"
+    "lint": "tsdx lint"
   },
   "peerDependencies": {
     "react": ">=16"


### PR DESCRIPTION
#### What does this PR do?

Context is best given by reading the attached card, but in a line: npm 7 breaks our build because the prepare script is called when we're not ready for it.

#### References

https://medibankdigital.atlassian.net/browse/SP-505